### PR TITLE
:construction_worker: add pip to dependabot management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
- # For details on how this file works refer to:
- #   - https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# For details on how this file works refer to:
+#   - https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 version: 2
 updates:
   # Maintain dependencies for GitHub Actions
@@ -11,4 +11,10 @@ updates:
       interval: weekly
     groups:
       all-actions:
-        patterns: [ "*" ]
+        patterns: ["*"]
+
+  # Maintain dependencies for Python
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
After workflow actions have been enabled, just to get builds to run and auto dependabot job to start after merge