### PR TITLE
:arrow_up: Upgrade ACA-Py to 0.12.1 for redis-events

### DIFF
--- a/redis_events/integration/poetry.lock
+++ b/redis_events/integration/poetry.lock
@@ -183,17 +183,17 @@ yaml = ["PyYAML (>=3.10)"]
 
 [[package]]
 name = "aries-cloudagent"
-version = "0.12.0"
+version = "0.12.1"
 description = "Hyperledger Aries Cloud Agent Python (ACA-Py) is a foundation for building decentralized identity applications and services running in non-mobile environments."
 optional = false
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "aries_cloudagent-0.12.0-py3-none-any.whl", hash = "sha256:0416d58fe53fe90107d4f7a77349d5b9082cb18dba1051bb9bf9d7c4ba5e3054"},
-    {file = "aries_cloudagent-0.12.0.tar.gz", hash = "sha256:dee04b11bd1eafeb866a0ec8437c9fa81dc607fcf3e7798976346ee08b58a9b9"},
+    {file = "aries_cloudagent-0.12.1-py3-none-any.whl", hash = "sha256:dcb6d6ed566bc3299ade60def33f1a1ada06276ad77a37e53210cda6c3fe9dd3"},
+    {file = "aries_cloudagent-0.12.1.tar.gz", hash = "sha256:de6da85c225ac641050a208c192e4b18882a0e7a94ed4879ed9b401ce450ecbc"},
 ]
 
 [package.dependencies]
-aiohttp = ">=3.9.2,<3.10.0"
+aiohttp = ">=3.9.4,<3.10.0"
 aiohttp-apispec = ">=2.2.1,<2.3.0"
 aiohttp-cors = ">=0.7.0,<0.8.0"
 apispec = ">=3.3.0,<3.4.0"
@@ -227,7 +227,7 @@ sd-jwt = ">=0.10.3,<0.11.0"
 unflatten = ">=0.1,<0.2"
 
 [package.extras]
-askar = ["anoncreds (==0.2.0.dev11)", "aries-askar (>=0.3.0,<0.4.0)", "indy-credx (>=1.1.1,<1.2.0)", "indy-vdr (>=0.4.0,<0.5.0)"]
+askar = ["anoncreds (==0.2.0)", "aries-askar (>=0.3.0,<0.4.0)", "indy-credx (>=1.1.1,<1.2.0)", "indy-vdr (>=0.4.0,<0.5.0)"]
 bbs = ["ursa-bbs-signatures (>=1.0.1,<1.1.0)"]
 indy = ["python3-indy (>=1.11.1,<2.0.0)"]
 
@@ -3002,4 +3002,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "0b64595568ccf862621a545b253d31db8f100be447a726c50695f669f0ce095e"
+content-hash = "7467db9ccd1a4bf5433a9172e7519ed4c59e10327c9a939003268524a0c5446b"

--- a/redis_events/integration/pyproject.toml
+++ b/redis_events/integration/pyproject.toml
@@ -10,7 +10,7 @@ pytest = "^8.2.0"
 pytest-asyncio = "^0.23.5"
 requests = "^2.31.0"
 aiohttp = "^3.9.5"
-aries-cloudagent = { version = "0.12.0" }
+aries-cloudagent = { version = "0.12.1" }
 fastapi = "^0.111.0"
 nest-asyncio = "^1.5.5"
 pydantic = "^1.10.15"

--- a/redis_events/poetry.lock
+++ b/redis_events/poetry.lock
@@ -212,17 +212,17 @@ cached-property = ">=1.5,<2.0"
 
 [[package]]
 name = "aries-cloudagent"
-version = "0.12.0"
+version = "0.12.1"
 description = "Hyperledger Aries Cloud Agent Python (ACA-Py) is a foundation for building decentralized identity applications and services running in non-mobile environments."
 optional = true
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "aries_cloudagent-0.12.0-py3-none-any.whl", hash = "sha256:0416d58fe53fe90107d4f7a77349d5b9082cb18dba1051bb9bf9d7c4ba5e3054"},
-    {file = "aries_cloudagent-0.12.0.tar.gz", hash = "sha256:dee04b11bd1eafeb866a0ec8437c9fa81dc607fcf3e7798976346ee08b58a9b9"},
+    {file = "aries_cloudagent-0.12.1-py3-none-any.whl", hash = "sha256:dcb6d6ed566bc3299ade60def33f1a1ada06276ad77a37e53210cda6c3fe9dd3"},
+    {file = "aries_cloudagent-0.12.1.tar.gz", hash = "sha256:de6da85c225ac641050a208c192e4b18882a0e7a94ed4879ed9b401ce450ecbc"},
 ]
 
 [package.dependencies]
-aiohttp = ">=3.9.2,<3.10.0"
+aiohttp = ">=3.9.4,<3.10.0"
 aiohttp-apispec = ">=2.2.1,<2.3.0"
 aiohttp-cors = ">=0.7.0,<0.8.0"
 apispec = ">=3.3.0,<3.4.0"
@@ -256,7 +256,7 @@ sd-jwt = ">=0.10.3,<0.11.0"
 unflatten = ">=0.1,<0.2"
 
 [package.extras]
-askar = ["anoncreds (==0.2.0.dev11)", "aries-askar (>=0.3.0,<0.4.0)", "indy-credx (>=1.1.1,<1.2.0)", "indy-vdr (>=0.4.0,<0.5.0)"]
+askar = ["anoncreds (==0.2.0)", "aries-askar (>=0.3.0,<0.4.0)", "indy-credx (>=1.1.1,<1.2.0)", "indy-vdr (>=0.4.0,<0.5.0)"]
 bbs = ["ursa-bbs-signatures (>=1.0.1,<1.1.0)"]
 indy = ["python3-indy (>=1.11.1,<2.0.0)"]
 
@@ -3503,4 +3503,4 @@ aca-py = ["aries-cloudagent"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "2b5597d7944f0bedfb1b7098e0f3c4502bb98035439d2bafadb1ec6c16bb689b"
+content-hash = "8027a9efdf7388f7b46798b888b64023854cd53fe605d1bf13c0a3974726562f"

--- a/redis_events/pyproject.toml
+++ b/redis_events/pyproject.toml
@@ -9,7 +9,7 @@ python = "^3.9"
 
 # Define ACA-Py as an optional/extra dependancy so it can be
 # explicitly installed with the plugin if desired.
-aries-cloudagent = { version = "0.12.0", optional = true }
+aries-cloudagent = { version = "0.12.1", optional = true }
 aiohttp = "^3.9.5"
 fastapi = "^0.111.0"
 nest-asyncio = "^1.5.5"


### PR DESCRIPTION
Signed-off-by: ff137 <ff137@proton.me>